### PR TITLE
Fixing line width

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -30,7 +30,10 @@ function main() {
     doc.set('image.tag', imageTag);
   }
   
-  const yamlOut = doc.toString();
+  const yamlOut = doc.toString({
+    lineWidth: 0,
+    minContentWidth: 0,
+  });
   fs.writeFileSync(outputFile, yamlOut);
 }
 


### PR DESCRIPTION
1. disabling line width because of which the strings were getting broken after default 80 chars